### PR TITLE
design: 문서, 작성하기, 편집하기 페이지에 대한 모바일 및 태블릿 대응 layout 적용

### DIFF
--- a/client/src/components/DocumentFooter.tsx
+++ b/client/src/components/DocumentFooter.tsx
@@ -8,7 +8,7 @@ interface DocumentFooterProps {
 const DocumentFooter = ({ generateTime }: DocumentFooterProps) => {
   const ment = `이 문서는 ${timeConverter(generateTime, 'YYYY년 M월 D일 (ddd) HH:mm')} 에 마지막으로 편집되었습니다.`;
   return (
-    <footer className="flex w-full h-fit py-6 px-8 bg-white border-primary-100 border-solid border rounded-xl p-8">
+    <footer className="flex w-full h-fit py-6 px-8 bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4">
       <p className="font-pretendard text-xs font-normal text-grayscale-800">{ment}</p>
     </footer>
   );

--- a/client/src/components/DocumentHeader.tsx
+++ b/client/src/components/DocumentHeader.tsx
@@ -21,9 +21,9 @@ const DocumentHeader = ({ wiki }: DocumentHeaderProps) => {
   };
 
   return (
-    <header className="flex justify-between w-full">
+    <header className="max-[768px]:flex-col-reverse max-[768px]:gap-4 flex justify-between w-full">
       <DocumentTitle title={wiki.title} />
-      <fieldset className="flex gap-2">
+      <fieldset className="flex gap-2 max-[768px]:w-full max-[768px]:justify-center">
         <Button style="tertiary" size="xs" text="새로고침" />
         <Button style="tertiary" size="xs" text="편집하기" onClick={goEditPage} />
         <Button style="tertiary" size="xs" text="편집로그" />

--- a/client/src/components/DocumentPage.tsx
+++ b/client/src/components/DocumentPage.tsx
@@ -23,7 +23,7 @@ const DocumentPage = ({ daemoon }: DocumentPageProps) => {
 
   return (
     <>
-      <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8">
+      <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-2 ">
         <DocumentHeader wiki={docs} />
         <DocumentContents contents={docs.contents} />
       </div>

--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -8,8 +8,8 @@ const Layout = () => {
     <div className="App bg-grayscale-50">
       <WikiHeader />
       <div className="flex items-center justify-center h-fit">
-        <main className="flex gap-6 py-6 px-4 max-w-[1440px] w-full">
-          <div className="flex flex-col gap-6 w-full">
+        <main className="flex gap-6 py-6 px-4 max-w-[1440px] w-full max-[768px]:py-2 max-[768px]:px-0">
+          <div className="flex flex-col gap-6 w-full max-[768px]:gap-2">
             <Outlet />
           </div>
           <RecentlyEditWrapper />

--- a/client/src/components/RecentlyEdit.tsx
+++ b/client/src/components/RecentlyEdit.tsx
@@ -8,7 +8,7 @@ const RecentlyEdit = () => {
   const { recentlyDocuments } = useGetRecentlyDocuments();
 
   return (
-    <aside className="flex flex-col w-60 h-fit bg-white border-primary-100 border-solid border rounded-xl">
+    <aside className="max-[1024px]:hidden flex flex-col w-60 h-fit bg-white border-primary-100 border-solid border rounded-xl">
       <h2 className="flex justify-center items-center w-full h-12 font-pretendard font-bold text-lg border-b border-primary-100">
         최근 편집
       </h2>

--- a/client/src/components/TitleInputField.tsx
+++ b/client/src/components/TitleInputField.tsx
@@ -18,20 +18,20 @@ const TitleInputField = ({ titleState, nicknameState, disabled }: TitleInputFiel
     <div className="flex flex-col gap-2 w-full">
       <div className="w-full font-pretendard text-error-error text-sm text-right">{nicknameState.errorMessage}</div>
       <div className="flex gap-6 w-full h-fit">
-        <div className="flex w-full h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2">
+        <div className="flex w-full h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2 max-[768px]:text-sm max-[768px]:h-10">
           <input
-            className="w-full outline-none font-bm text-2xl text-grayscale-800 placeholder:text-grayscale-lightText"
-            placeholder="작성할 문서의 제목을 입력해 주세요"
+            className="w-full outline-none font-bm text-2xl text-grayscale-800 placeholder:text-grayscale-lightText max-[768px]:text-sm"
+            placeholder="문서의 제목을 입력해 주세요"
             value={titleState.title}
             onChange={titleState.setTitle}
             maxLength={12}
             disabled={disabled}
           />
         </div>
-        <div className="flex w-36 h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2">
+        <div className="flex w-36 h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2 max-[768px]:text-sm  max-[768px]:h-10">
           <input
-            className="w-full outline-none font-bm text-2xl text-grayscale-800 placeholder:text-grayscale-lightText"
-            placeholder="닉네임"
+            className="w-full outline-none font-bm text-2xl text-grayscale-800 placeholder:text-grayscale-lightText max-[768px]:text-sm"
+            placeholder="편집자"
             value={nicknameState.nickname}
             onChange={nicknameState.setNickname}
           />

--- a/client/src/components/WritePage.tsx
+++ b/client/src/components/WritePage.tsx
@@ -35,7 +35,7 @@ const WritePage = ({ mode, writeDocument, isPending, defaultDocumentData }: Writ
     writeDocument(context);
   };
   return (
-    <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8">
+    <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-3">
       <PostHeader mode={mode} onClick={onClick} isPending={isPending} />
       <TitleInputField titleState={titleState} nicknameState={nicknameState} disabled={mode === 'edit'} />
       <PostContents editorRef={editorRef} initialValue={defaultDocumentData?.contents} />


### PR DESCRIPTION
# 작업 이름 (이것 지우고 적어주시면 됩니다)

## 주요 변경 내용
- layout.tsx width에 대한 반응형 디자인 적용
- 작성 / 편집하기 페이지 width에 대한 반응형 디자인 적용 
- 문서 페이지 width에 대한 반응형 디자인 적용

## 참고 사항
- 해상도에 따른 font 조절을 위해 모바일 기기에서 직접 확인한 뒤 조절할 필요 있음

## 남은 작업 내용
- 편집하기 inputfield disabled design

## 참고용 시연 사진

https://github.com/Crew-Wiki/frontend/assets/85233397/848307a8-be76-43e3-9f98-5d554d316fdc


https://github.com/Crew-Wiki/frontend/assets/85233397/9faa6f20-5358-449f-9447-0ccd23e44b80


