### PR TITLE
Feat: Tui에디터 마크다운 설정. 화면크기에따라 반응

### DIFF
--- a/client/src/components/markdownEditor/TuiEditor.tsx
+++ b/client/src/components/markdownEditor/TuiEditor.tsx
@@ -15,6 +15,7 @@ const toolbar = [
   ['heading', 'bold', 'italic', 'strike'],
   ['hr', 'quote', 'ul', 'ol'],
   ['image', 'link'],
+  ['scrollSync'],
 ];
 
 function TuiEditor({ content, editorRef, imageHandler }: Props) {

--- a/client/src/components/markdownEditor/TuiEditor.tsx
+++ b/client/src/components/markdownEditor/TuiEditor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Editor } from '@toast-ui/react-editor';
 import '@toast-ui/editor/toastui-editor.css';
+import { log } from 'console';
 
 type HookCallback = (url: string, text?: string) => void;
 
@@ -17,14 +18,16 @@ const toolbar = [
 ];
 
 function TuiEditor({ content, editorRef, imageHandler }: Props) {
+  const isDesktop = window.screen.availWidth >= 768;
   return (
     <Editor
       initialValue={content ?? '내용을 입력해주세요'}
-      initialEditType="wysiwyg"
+      initialEditType="markdown"
       autofocus={false}
+      previewStyle={isDesktop ? 'vertical' : 'tab'}
       ref={editorRef}
       toolbarItems={toolbar}
-      hideModeSwitch
+      hideModeSwitch={true}
       height="500px"
       hooks={{ addImageBlobHook: imageHandler }}
     />

--- a/client/src/components/markdownEditor/TuiEditor.tsx
+++ b/client/src/components/markdownEditor/TuiEditor.tsx
@@ -19,7 +19,7 @@ const toolbar = [
 ];
 
 function TuiEditor({ content, editorRef, imageHandler }: Props) {
-  const isDesktop = window.screen.availWidth >= 768;
+  const isDesktop = window.innerWidth >= 768;
   return (
     <Editor
       initialValue={content ?? '내용을 입력해주세요'}


### PR DESCRIPTION
# 작업 이름 (이것 지우고 적어주시면 됩니다)

## 주요 변경 내용
- 기존엔 wysiwyg 환경이어서 이미지를 넣을때 마크다운이 제대로 되지않았음.

변경후
[사진 참고 !]
모바일환경 : write/ preview 모드적용
데탑환경 : write와 preview를 같이보면서 작업가능
(화면 768기준)


## 참고 사항
- 데스크톱일경우에도 그냥 모바일처럼 모드전환하게 하는게 나을지
그냥 지금처럼이 나을지
그것도 생각해보면 좋을듯합니다.
- window.innerWidth >=768 기준으로 모드전환해놓았습니다.

## 남은 작업 내용
-

## 참고용 시연 사진
- 모바일일경우 (write / preview 모드 변경가능)
![스크린샷 2024-03-30 190120](https://github.com/Crew-Wiki/frontend/assets/86130706/828558ce-9237-4648-9d39-eba9e258c389)
![스크린샷 2024-03-30 190113](https://github.com/Crew-Wiki/frontend/assets/86130706/7f5cad4e-4b2c-4bb3-b9ad-2d52dca4eedc)
- 데스크톱일 경우 같이보며 작업가능.
![스크린샷 2024-03-30 190154](https://github.com/Crew-Wiki/frontend/assets/86130706/7bc9a67b-bbbc-47b9-9391-8534b6b83a14)


