### PR TITLE
Feat: 9 responsive wiki header/모바일에서 위키헤더 높이 줄이기

### DIFF
--- a/client/src/components/WikiHeader.tsx
+++ b/client/src/components/WikiHeader.tsx
@@ -5,7 +5,7 @@ import WikiInputField from './WikiInputField';
 
 const WikiHeader = () => {
   return (
-    <header className="flex w-full h-20 bg-primary-primary justify-center">
+    <header className="flex w-full h-12 md:h-20 bg-primary-primary justify-center">
       <div className="flex justify-between items-center px-4 header-container max-w-[1440px] w-full">
         <Link to="/">
           <h1 className="font-bm text-2xl text-white font-normal">크루위키</h1>


### PR DESCRIPTION
# 모바일에서 위키헤더 높이 줄이기

## 주요 변경 내용
- 모바일에서 위키 헤더 높이는 80px->48px(3rem)으로 줄어야 하는데 반영되지않았어서 추가했습니다.

## 참고 사항
-

## 남은 작업 내용
-

## 참고용 시연 사진
-적용 후 모바일에서는 위키헤더 (청록색) 높이가 줄어듭니다.
![스크린샷 2024-03-31 020822](https://github.com/Crew-Wiki/frontend/assets/86130706/13889c5c-f296-4e39-9638-60bd34d623cb)
![스크린샷 2024-03-31 020828](https://github.com/Crew-Wiki/frontend/assets/86130706/4ee8c90d-656d-44d6-a3f9-afffcefc966f)

