### PR TITLE
Feature/12 header toggle

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-dom": "^18.2.22",
         "axios": "^1.6.7",
         "dayjs": "^1.11.10",
+        "framer-motion": "^11.0.24",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.13",
@@ -9552,6 +9553,30 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.0.24",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.24.tgz",
+      "integrity": "sha512-l2iM8NR53qtcujgAqYvGPJJGModPNWEVUaATRDLfnaLvUoFpImovBm0AHalSSsY8tW6knP8mfJTW4WYGbnAe4w==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^18.2.22",
     "axios": "^1.6.7",
     "dayjs": "^1.11.10",
+    "framer-motion": "^11.0.24",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.13",

--- a/client/src/components/DocumentPage.tsx
+++ b/client/src/components/DocumentPage.tsx
@@ -23,7 +23,7 @@ const DocumentPage = ({ daemoon }: DocumentPageProps) => {
 
   return (
     <>
-      <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-2 ">
+      <div className="flex flex-col gap-6 w-full h-fit min-h-[864px] bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-2">
         <DocumentHeader wiki={docs} />
         <DocumentContents contents={docs.contents} />
       </div>

--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -30,7 +30,7 @@ const Layout = () => {
   }, [window.scrollY]);
 
   return (
-    <div className="App bg-grayscale-50">
+    <div className="App">
       <WikiHeader isShown={showHeader} />
       <div className="flex items-center justify-center h-fit mt-20 max-[768px]:mt-12">
         <main className="flex gap-6 py-6 px-4 max-w-[1440px] w-full max-[768px]:py-2 max-[768px]:px-0">

--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -1,13 +1,38 @@
-import React from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { Outlet } from 'react-router-dom';
 import RecentlyEditWrapper from '@components/RecentlyEditWrapper';
 import WikiHeader from '../WikiHeader';
 
+interface ScrollPosition {
+  prev: number;
+  current: number;
+}
+
 const Layout = () => {
+  const [scrollPosition, setScrollPosition] = useState<ScrollPosition>({
+    prev: window.scrollY,
+    current: window.scrollY,
+  });
+  const [showHeader, setShowHeader] = useState(true);
+
+  const handleScroll = () => {
+    setScrollPosition({ prev: scrollPosition.current, current: window.scrollY });
+    setShowHeader(scrollPosition.prev >= scrollPosition.current);
+    if (window.scrollY < 50) {
+      setShowHeader(true);
+    }
+  };
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [window.scrollY]);
+
   return (
     <div className="App bg-grayscale-50">
-      <WikiHeader />
-      <div className="flex items-center justify-center h-fit">
+      <WikiHeader isShown={showHeader} />
+      <div className="flex items-center justify-center h-fit mt-20 max-[768px]:mt-12">
         <main className="flex gap-6 py-6 px-4 max-w-[1440px] w-full max-[768px]:py-2 max-[768px]:px-0">
           <div className="flex flex-col gap-6 w-full max-[768px]:gap-2">
             <Outlet />

--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -1,37 +1,12 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React from 'react';
 import { Outlet } from 'react-router-dom';
 import RecentlyEditWrapper from '@components/RecentlyEditWrapper';
 import WikiHeader from '../WikiHeader';
 
-interface ScrollPosition {
-  prev: number;
-  current: number;
-}
-
 const Layout = () => {
-  const [scrollPosition, setScrollPosition] = useState<ScrollPosition>({
-    prev: window.scrollY,
-    current: window.scrollY,
-  });
-  const [showHeader, setShowHeader] = useState(true);
-
-  const handleScroll = () => {
-    setScrollPosition({ prev: scrollPosition.current, current: window.scrollY });
-    setShowHeader(scrollPosition.prev >= scrollPosition.current);
-    if (window.scrollY < 50) {
-      setShowHeader(true);
-    }
-  };
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, [window.scrollY]);
-
   return (
     <div className="App">
-      <WikiHeader isShown={showHeader} />
+      <WikiHeader />
       <div className="flex items-center justify-center h-fit mt-20 max-[768px]:mt-12">
         <main className="flex gap-6 py-6 px-4 max-w-[1440px] w-full max-[768px]:py-2 max-[768px]:px-0">
           <div className="flex flex-col gap-6 w-full max-[768px]:gap-2">

--- a/client/src/components/WikiHeader.tsx
+++ b/client/src/components/WikiHeader.tsx
@@ -4,20 +4,41 @@ import { Link } from 'react-router-dom';
 import { ReactComponent as SearchCircleSmall } from '@assets/image/search-circle.svg';
 import WikiInputField from './WikiInputField';
 
-interface WikiHeaderProps {
-  isShown: boolean;
+interface ScrollPosition {
+  prev: number;
+  current: number;
 }
 
-const WikiHeader = ({ isShown }: WikiHeaderProps) => {
+const WikiHeader = () => {
+  const [scrollPosition, setScrollPosition] = useState<ScrollPosition>({
+    prev: window.scrollY,
+    current: window.scrollY,
+  });
+  const [showHeader, setShowHeader] = useState(true);
   const [y, setY] = useState(0);
 
+  const handleScroll = () => {
+    setScrollPosition({ prev: scrollPosition.current, current: window.scrollY });
+    setShowHeader(scrollPosition.prev >= scrollPosition.current);
+    if (window.scrollY < 50) {
+      setShowHeader(true);
+    }
+  };
+
   useEffect(() => {
-    if (isShown) {
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [window.scrollY]);
+
+  useEffect(() => {
+    if (showHeader) {
       setY(0);
     } else {
       setY(-80);
     }
-  }, [isShown]);
+  }, [showHeader]);
 
   return (
     <motion.div

--- a/client/src/components/WikiHeader.tsx
+++ b/client/src/components/WikiHeader.tsx
@@ -1,11 +1,30 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { ReactComponent as SearchCircleSmall } from '@assets/image/search-circle.svg';
 import WikiInputField from './WikiInputField';
 
-const WikiHeader = () => {
+interface WikiHeaderProps {
+  isShown: boolean;
+}
+
+const WikiHeader = ({ isShown }: WikiHeaderProps) => {
+  const [y, setY] = useState(0);
+
+  useEffect(() => {
+    if (isShown) {
+      setY(0);
+    } else {
+      setY(-80);
+    }
+  }, [isShown]);
+
   return (
-    <header className="flex w-full h-12 md:h-20 bg-primary-primary justify-center">
+    <motion.div
+      className="fixed top-0 flex w-full h-12 md:h-20 bg-primary-primary justify-center"
+      animate={{ y }}
+      transition={{ duration: 0.3 }}
+    >
       <div className="flex justify-between items-center px-4 header-container max-w-[1440px] w-full">
         <Link to="/">
           <h1 className="font-bm text-2xl text-white font-normal">크루위키</h1>
@@ -13,7 +32,7 @@ const WikiHeader = () => {
         <WikiInputField className="w-20 md:w-[20.25rem] hidden md:flex" />
         <SearchCircleSmall className="cursor-pointer md:hidden" />
       </div>
-    </header>
+    </motion.div>
   );
 };
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -23,7 +23,7 @@
     font-weight: 400;
     font-size: 1.375rem;
     line-height: 150%;
-    }
+  }
 }
 
 @layer head {
@@ -47,6 +47,9 @@
     font-weight: 400;
     font-size: 2.25rem;
     line-height: 150%;
-    }
+  }
 }
 
+html {
+  background-color: #f3f4f6;
+}


### PR DESCRIPTION
# 스크롤 반응형 헤더 구현

## 주요 변경 내용
- 스크롤 방향에 따라 헤더 toggle
- 배경색 영역을 app이 아니라 html 영역으로 변경
- 문서의 길이가 짧을 때, min-height 864px 적용

## 참고 사항
- x

## 남은 작업 내용
- x

## 참고용 시연 사진
- 스크롤에 따른 헤더 변경
(왜 잘됐던 게 갑자기 안됨, 알아서 보셈 ㅡㅡ
https://github.com/Crew-Wiki/frontend/pull/10 여기선 잘 됐음 내탓 아님)
https://github.com/Crew-Wiki/frontend/assets/85233397/e160c196-05d4-4f61-8a4e-ba8aa4661d81

- 문서의 길이가 짧은 경우
![image](https://github.com/Crew-Wiki/frontend/assets/85233397/b6b37db3-3fbb-4a63-b1a5-e81ad3dbcb0b)

