### PR TITLE
feat: 1000px 초과하는 image 들에 대해서 resizing 적용

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -28,6 +28,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.13",
+        "react-image-file-resizer": "^0.4.8",
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
         "tailwind-merge": "^2.2.2",
@@ -16223,6 +16224,11 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-image-file-resizer": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/react-image-file-resizer/-/react-image-file-resizer-0.4.8.tgz",
+      "integrity": "sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ=="
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.13",
+    "react-image-file-resizer": "^0.4.8",
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
     "tailwind-merge": "^2.2.2",


### PR DESCRIPTION
# 1000px 이상 넘어가는 이미지에 대해서 resizing 적용

## 주요 변경 내용
- width  혹은 height 1000px이 넘어가는 경우에 더 큰 쪽의 maximum 1000px을 적용

## 참고 사항
- react-image-file-resizer 라이브러리 설치

## 남은 작업 내용
- x

## 참고용 시연 사진
- resizing 적용 전
![image](https://github.com/Crew-Wiki/frontend/assets/85233397/ac3a3fc3-d8f3-43d1-ab6e-17faea79f296)

- resizing 적용 후
![image](https://github.com/Crew-Wiki/frontend/assets/85233397/78335761-e6b0-4fc2-9e8b-edf826ae4856)
