### PR TITLE
Feat: 15. 글 작성시 제목, 닉네임 중 하나라도 비어있으면 버튼 비활성화

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
+
+type ButtonState = 'default'|'disabled'|'pressed';
+type ButtonStyle = 'primary' | 'secondary' | 'tertiary' | 'text';
 
 interface ButtonProps {
   size: 'm' | 's' | 'xs';
-  style: 'primary' | 'secondary' | 'tertiary' | 'text';
+  style: ButtonStyle;
   text: string;
   type?: 'button' | 'reset' | 'submit';
   disabled?: boolean;
@@ -11,21 +14,47 @@ interface ButtonProps {
 }
 
 const Button = ({ size, type, style, text, disabled, onClick }: ButtonProps) => {
+
+  const [buttonState, setButtonState] = useState<ButtonState>('default');
+  if (disabled && buttonState !== 'disabled'){
+    setButtonState('disabled');
+  }
+  if (!disabled && buttonState === 'disabled') {
+    setButtonState('default');
+  }
+
   const BUTTONSIZE = {
     xs: 'h-9 rounded-[1.125rem] px-3',
     s: 'h-11 rounded-[1.375rem] px-4',
     m: 'h-14 rounded-[1.75rem] px-4',
   };
-  const BUTTONSTYLE = {
+  
+  const BUTTON_STYLE:Record<ButtonState, Record<ButtonStyle,string>> = {
+    default:{
     primary: 'bg-primary-primary text-white',
     secondary: 'bg-white text-primary-primary border-primary-primary border-solid border',
     tertiary: 'bg-white text-grayscale-lightText border-grayscale-border border-solid border',
-    text: 'bg-white text-primary-primary shadow-md',
+    text: 'bg-white text-primary-primary shadow-md'
+      },
+    disabled:{
+      primary: 'bg-grayscale-100 text-grayscale-400',
+    secondary: 'bg-grayscale-50 text-grayscale-400 border-grayscale-100 border-solid border',
+    tertiary: 'bg-grayscale-50 text-grayscale-400 border-grayscale-100 border-grayscale-border border-solid border',
+    text: 'bg-grayscale-100 text-grayscale-400 shadow-md'
+      },
+    pressed:{
+      primary: 'bg-grayscale-100 ',
+      secondary: 'bg-grayscale-100 ',
+      tertiary: 'bg-grayscale-100 ',
+      text: 'bg-grayscale-100 '
+    }
   };
+
+
   return (
     <button
       type={type}
-      className={twMerge('font-bm text-sm', BUTTONSIZE[size], BUTTONSTYLE[style])}
+      className={twMerge('font-bm text-sm', BUTTONSIZE[size], BUTTON_STYLE[buttonState][style])}
       disabled={disabled}
       onClick={onClick}
     >

--- a/client/src/components/PostHeader.tsx
+++ b/client/src/components/PostHeader.tsx
@@ -7,6 +7,7 @@ interface PostHeaderProps {
   mode: 'add' | 'edit';
   onClick: () => void;
   isPending: boolean;
+  isInputEmpty: boolean;
 }
 
 const MODE_TITLE: Record<string, string> = {
@@ -14,7 +15,7 @@ const MODE_TITLE: Record<string, string> = {
   edit: '편집하기',
 };
 
-const PostHeader = ({ mode, onClick, isPending }: PostHeaderProps) => {
+const PostHeader = ({ mode, onClick, isPending, isInputEmpty }: PostHeaderProps) => {
   // isPending과 validation 연산해서 버튼의 disabled 넘겨주기
   const navigate = useNavigate();
 
@@ -27,7 +28,7 @@ const PostHeader = ({ mode, onClick, isPending }: PostHeaderProps) => {
       <DocumentTitle title={MODE_TITLE[mode]} />
       <fieldset className="flex gap-2">
         <Button style="tertiary" size="xs" text="취소하기" onClick={goBack} />
-        <Button style="primary" size="xs" text="작성완료" onClick={onClick} disabled={isPending} />
+        <Button style="primary" size="xs" text="작성완료" onClick={onClick} disabled={isPending||isInputEmpty} />
       </fieldset>
     </header>
   );

--- a/client/src/components/WritePage.tsx
+++ b/client/src/components/WritePage.tsx
@@ -39,6 +39,9 @@ const WritePage = ({ mode, writeDocument, isPending, defaultDocumentData }: Writ
     return newContents;
   };
 
+  const isInputEmpty =  titleState.title === '' || nicknameState.nickname === '';
+  
+
   const onClick = async () => {
     if (editorRef === null) return;
     const newMetas = await uploadImages(titleState.title, images);
@@ -54,7 +57,7 @@ const WritePage = ({ mode, writeDocument, isPending, defaultDocumentData }: Writ
   };
   return (
     <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-3">
-      <PostHeader mode={mode} onClick={onClick} isPending={isPending} />
+      <PostHeader mode={mode} onClick={onClick} isPending={isPending} isInputEmpty={isInputEmpty} />
       <TitleInputField titleState={titleState} nicknameState={nicknameState} disabled={mode === 'edit'} />
       <PostContents editorRef={editorRef} initialValue={defaultDocumentData?.contents} setImages={setImages} />
     </div>


### PR DESCRIPTION
# 글 작성시 제목, 닉네임 중 하나라도 비어있으면 버튼 비활성화

## 주요 변경 내용
- 버튼에 비활성화 기능추가
- 버튼의 상태(state:disable, default, pressed)에 따라 스타일이 변경되도록 구현
- 글 작성시 제목, 닉네임이 비어있으면 제출버튼 비활성화

## 참고 사항
- 버튼의 상태기억을 위해 useState

## 남은 작업 내용
-

## 참고용 시연 사진
![스크린샷 2024-04-03 142615](https://github.com/Crew-Wiki/frontend/assets/86130706/4ebafc3b-73fb-46a2-95ec-181989a86dbe)

![스크린샷 2024-04-03 142618](https://github.com/Crew-Wiki/frontend/assets/86130706/1a40ad8d-64f7-4cb9-a6a7-5bf4fa1ce75c)
