### PR TITLE
Feat: fallback 개선, 중복 문서 early check

### DIFF
--- a/client/src/components/DocumentFallback.tsx
+++ b/client/src/components/DocumentFallback.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { AxiosError } from 'axios';
 
 import { FallbackProps } from 'react-error-boundary';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import URLS from '@constants/urls';
 import DocumentTitle from './DocumentTitle';
+import Button from './Button';
 
 interface Error {
   errorMessage: string;
@@ -13,12 +15,20 @@ const DocumentFallback = ({ error }: FallbackProps) => {
   const axiosError = error as AxiosError;
   const errorDetail = axiosError.response?.data as Error;
 
+  const navigate = useNavigate();
   const { title } = useParams();
 
+  const goPostPage = () => {
+    navigate(URLS.POST);
+  };
+
   return (
-    <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8">
-      <header className="flex justify-between w-full">
+    <div className="flex flex-col gap-6 w-full h-fit min-h-[864px] bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-2">
+      <header className="max-[768px]:flex-col-reverse max-[768px]:gap-4 flex justify-between w-full">
         <DocumentTitle title={title ?? ''} />
+        <fieldset className="flex gap-2 max-[768px]:w-full max-[768px]:justify-center">
+          <Button style="primary" size="xs" text="작성하기" onClick={goPostPage} />
+        </fieldset>
       </header>
       {errorDetail.errorMessage}
     </div>

--- a/client/src/components/TitleInputField.tsx
+++ b/client/src/components/TitleInputField.tsx
@@ -3,7 +3,9 @@ import React from 'react';
 interface TitleInputFieldProps {
   titleState: {
     title: string;
-    setTitle: (state: string | React.ChangeEvent<HTMLInputElement>) => void;
+    setTitle: (event: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+    errorMessage: string;
+    isAlreadyWritten: () => Promise<void>;
   };
   nicknameState: {
     nickname: string;
@@ -16,7 +18,10 @@ interface TitleInputFieldProps {
 const TitleInputField = ({ titleState, nicknameState, disabled }: TitleInputFieldProps) => {
   return (
     <div className="flex flex-col gap-2 w-full">
-      <div className="w-full font-pretendard text-error-error text-sm text-right">{nicknameState.errorMessage}</div>
+      <div className="flex w-full justify-between">
+        <div className="font-pretendard text-error-error text-sm text-right">{titleState.errorMessage}</div>
+        <div className="font-pretendard text-error-error text-sm text-right">{nicknameState.errorMessage}</div>
+      </div>
       <div className="flex gap-6 w-full h-fit">
         <div className="flex w-full h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2 max-[768px]:text-sm max-[768px]:h-10">
           <input
@@ -26,6 +31,7 @@ const TitleInputField = ({ titleState, nicknameState, disabled }: TitleInputFiel
             onChange={titleState.setTitle}
             maxLength={12}
             disabled={disabled}
+            onBlur={titleState.isAlreadyWritten}
           />
         </div>
         <div className="flex w-36 h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2 max-[768px]:text-sm  max-[768px]:h-10">

--- a/client/src/hooks/usePostPage.ts
+++ b/client/src/hooks/usePostPage.ts
@@ -1,14 +1,16 @@
 import { WikiDocument } from '@type/DocumentType';
-import useInput from './useInput';
 import useNicknameInput from './useNicknameInput';
+import useTitleInput from './useTitleInput';
 
 const usePostPage = (defaultDocumentData?: WikiDocument) => {
-  const [title, setTitle] = useInput<string>(defaultDocumentData?.title ?? '');
+  const [title, setTitle, , titleErrorMessage, isAlreadyWritten] = useTitleInput(defaultDocumentData?.title ?? '');
   const [nickname, setNickname, , errorMessage] = useNicknameInput(defaultDocumentData?.writer ?? '');
 
   const titleState = {
     title,
     setTitle,
+    errorMessage: titleErrorMessage,
+    isAlreadyWritten,
   };
 
   const nicknameState = {

--- a/client/src/hooks/useTitleInput.ts
+++ b/client/src/hooks/useTitleInput.ts
@@ -1,0 +1,33 @@
+import { WikiDocument } from '@type/DocumentType';
+import axiosInstance from '@utils/axios';
+import React, { useCallback, useState } from 'react';
+import ENDPOINT from '@constants/endpoint';
+
+const { GET_DOCUMENT_BY_TITLE } = ENDPOINT;
+
+function useTitleInput(init: string) {
+  const [value, setValue] = useState<string>(init);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const isAlreadyWritten = async () => {
+    try {
+      await axiosInstance.get<WikiDocument>(`${GET_DOCUMENT_BY_TITLE}/${value}`);
+      setErrorMessage('이미 있는 문서입니다.');
+    } catch (error) {
+      setErrorMessage('');
+    }
+  };
+
+  const onChange = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    setValue(newValue);
+  }, []);
+
+  const reset = useCallback(() => {
+    setValue(init);
+    setErrorMessage('');
+  }, [init]);
+  return [value, onChange, reset, errorMessage, isAlreadyWritten] as const;
+}
+
+export default useTitleInput;


### PR DESCRIPTION
# fallback 개선, 중복 문서 early check

## 주요 변경 내용
- 없는 문서일 때 ui를 개선했습니다.
- 중복된 문서를 미리 알려줄 수 있도록 했습니다. onBlur일 때 중복체크 일어납니다.

## 참고 사항
-

## 남은 작업 내용
-

## 참고용 시연 사진
![image](https://github.com/Crew-Wiki/frontend/assets/81083461/a10d2429-2164-441c-ae43-af4f562181c3)
![image](https://github.com/Crew-Wiki/frontend/assets/81083461/ea54f405-e696-4f84-8832-ebb01a4c0a14)
