### PR TITLE
Feat: 편집로그 api 연결 및 로그 상세 연결

### DIFF
--- a/client/src/api/get/useGetDocumentLogs.ts
+++ b/client/src/api/get/useGetDocumentLogs.ts
@@ -2,13 +2,13 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import KEYS from '@constants/keys';
 import axiosInstance from '@utils/axios';
 import ENDPOINT from '@constants/endpoint';
-import { WikiDocumentLog } from '@type/DocumentType';
+import { WikiDocumentLogSummary } from '@type/DocumentType';
 
 const { QUERY } = KEYS;
 
 const useGetDocumentLogs = (title: string) => {
   const getDocumentLogs = async () => {
-    const response = await axiosInstance.get<WikiDocumentLog[]>(ENDPOINT.GET_DOCUMENT_LOGS(title));
+    const response = await axiosInstance.get<WikiDocumentLogSummary[]>(ENDPOINT.GET_DOCUMENT_LOGS(title));
     return response.data;
   };
 
@@ -16,7 +16,7 @@ const useGetDocumentLogs = (title: string) => {
     queryKey: [QUERY.GET_DOCUMENT_LOGS, title],
     queryFn: getDocumentLogs,
     select: (logs) =>
-      logs.sort((a: WikiDocumentLog, b: WikiDocumentLog) => (a.generateTime <= b.generateTime ? 1 : -1)),
+      logs.sort((a: WikiDocumentLogSummary, b: WikiDocumentLogSummary) => (a.generateTime <= b.generateTime ? 1 : -1)),
   });
 
   return {

--- a/client/src/api/get/useGetSpecificDocumentLog.ts
+++ b/client/src/api/get/useGetSpecificDocumentLog.ts
@@ -1,6 +1,6 @@
 import axiosInstance from '@utils/axios';
 import ENDPOINT from '@constants/endpoint';
-import { WikiDocumentLog } from '@type/DocumentType';
+import { WikiDocumentLogDetail } from '@type/DocumentType';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import KEYS from '@constants/keys';
 
@@ -9,7 +9,7 @@ const { QUERY } = KEYS;
 
 const useGetSpecificDocumentLog = (logId: number) => {
   const getSpecificDocumentLog = async () => {
-    const response = await axiosInstance.get<WikiDocumentLog>(GET_SPECIFIC_DOCUMENT_LOG(logId));
+    const response = await axiosInstance.get<WikiDocumentLogDetail>(GET_SPECIFIC_DOCUMENT_LOG(logId));
     return response.data;
   };
 

--- a/client/src/components/DocumentFallback.tsx
+++ b/client/src/components/DocumentFallback.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { AxiosError } from 'axios';
 
 import { FallbackProps } from 'react-error-boundary';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import URLS from '@constants/urls';
 import DocumentTitle from './DocumentTitle';
+import Button from './Button';
 
 interface Error {
   errorMessage: string;
@@ -13,12 +15,20 @@ const DocumentFallback = ({ error }: FallbackProps) => {
   const axiosError = error as AxiosError;
   const errorDetail = axiosError.response?.data as Error;
 
+  const navigate = useNavigate();
   const { title } = useParams();
 
+  const goPostPage = () => {
+    navigate(URLS.POST);
+  };
+
   return (
-    <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8">
-      <header className="flex justify-between w-full">
+    <div className="flex flex-col gap-6 w-full h-fit min-h-[864px] bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-2">
+      <header className="max-[768px]:flex-col-reverse max-[768px]:gap-4 flex justify-between w-full">
         <DocumentTitle title={title ?? ''} />
+        <fieldset className="flex gap-2 max-[768px]:w-full max-[768px]:justify-center">
+          <Button style="primary" size="xs" text="작성하기" onClick={goPostPage} />
+        </fieldset>
       </header>
       {errorDetail.errorMessage}
     </div>

--- a/client/src/components/EachLogContent.tsx
+++ b/client/src/components/EachLogContent.tsx
@@ -1,22 +1,33 @@
 import React from 'react';
-import { WikiDocumentLog } from '@type/DocumentType';
+import { WikiDocumentLogSummary } from '@type/DocumentType';
 import timeConverter from '@utils/TimeConverter';
+import { useNavigate } from 'react-router-dom';
+import URLS from '@constants/urls';
 import Button from './Button';
 
 interface EachLogContentProps {
-  documentLog: WikiDocumentLog;
-  index: number;
+  title: string;
+  summary: WikiDocumentLogSummary;
 }
 
-const EachLogContent = ({ index, documentLog: { generateTime } }: EachLogContentProps) => {
+const EachLogContent = ({
+  title,
+  summary: { logId, writer, version, generateTime, documentBytes },
+}: EachLogContentProps) => {
+  const navigate = useNavigate();
+
+  const goLogDetail = () => {
+    navigate(`${URLS.WIKI}/${title}/log/${logId}`);
+  };
+
   return (
     <tr className="w-full font-pretendard text-xs">
-      <td className="w-10 text-center">{index}</td>
+      <td className="w-10 text-center">{version}</td>
       <td className="text-center">{timeConverter(generateTime, 'YYYY년 M월 D일 (ddd) HH:mm:ss')}</td>
-      <td className="w-28 text-center">8192 byte</td>
-      <td className="w-16 text-center">토다리</td>
+      <td className="w-28 text-center">{`${documentBytes ?? 0}bytes`}</td>
+      <td className="w-16 text-center">{writer}</td>
       <td className="w-16 text-center">
-        <Button size="xxs" style="text" text="조회" type="button" />
+        <Button size="xxs" style="text" text="조회" type="button" onClick={goLogDetail} />
       </td>
     </tr>
   );

--- a/client/src/components/LogsContents.tsx
+++ b/client/src/components/LogsContents.tsx
@@ -28,8 +28,8 @@ const LogsContents = ({ title }: LogsContentsProps) => {
         </tr>
       </thead>
       <tbody>
-        {documentLogs.map((docs, index) => (
-          <EachLogContent key={index} index={documentLogs.length - index} documentLog={docs} />
+        {documentLogs.map((docs) => (
+          <EachLogContent key={docs.logId} title={title} summary={docs} />
         ))}
       </tbody>
     </table>

--- a/client/src/components/TitleInputField.tsx
+++ b/client/src/components/TitleInputField.tsx
@@ -3,7 +3,9 @@ import React from 'react';
 interface TitleInputFieldProps {
   titleState: {
     title: string;
-    setTitle: (state: string | React.ChangeEvent<HTMLInputElement>) => void;
+    setTitle: (event: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+    errorMessage: string;
+    isAlreadyWritten: () => Promise<void>;
   };
   nicknameState: {
     nickname: string;
@@ -16,7 +18,10 @@ interface TitleInputFieldProps {
 const TitleInputField = ({ titleState, nicknameState, disabled }: TitleInputFieldProps) => {
   return (
     <div className="flex flex-col gap-2 w-full">
-      <div className="w-full font-pretendard text-error-error text-sm text-right">{nicknameState.errorMessage}</div>
+      <div className="flex w-full justify-between">
+        <div className="font-pretendard text-error-error text-sm text-right">{titleState.errorMessage}</div>
+        <div className="font-pretendard text-error-error text-sm text-right">{nicknameState.errorMessage}</div>
+      </div>
       <div className="flex gap-6 w-full h-fit">
         <div className="flex w-full h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2 max-[768px]:text-sm max-[768px]:h-10">
           <input
@@ -26,6 +31,7 @@ const TitleInputField = ({ titleState, nicknameState, disabled }: TitleInputFiel
             onChange={titleState.setTitle}
             maxLength={12}
             disabled={disabled}
+            onBlur={titleState.isAlreadyWritten}
           />
         </div>
         <div className="flex w-36 h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2 max-[768px]:text-sm  max-[768px]:h-10">

--- a/client/src/hooks/usePostPage.ts
+++ b/client/src/hooks/usePostPage.ts
@@ -1,14 +1,16 @@
 import { WikiDocument } from '@type/DocumentType';
-import useInput from './useInput';
 import useNicknameInput from './useNicknameInput';
+import useTitleInput from './useTitleInput';
 
 const usePostPage = (defaultDocumentData?: WikiDocument) => {
-  const [title, setTitle] = useInput<string>(defaultDocumentData?.title ?? '');
+  const [title, setTitle, , titleErrorMessage, isAlreadyWritten] = useTitleInput(defaultDocumentData?.title ?? '');
   const [nickname, setNickname, , errorMessage] = useNicknameInput(defaultDocumentData?.writer ?? '');
 
   const titleState = {
     title,
     setTitle,
+    errorMessage: titleErrorMessage,
+    isAlreadyWritten,
   };
 
   const nicknameState = {

--- a/client/src/hooks/useTitleInput.ts
+++ b/client/src/hooks/useTitleInput.ts
@@ -1,0 +1,33 @@
+import { WikiDocument } from '@type/DocumentType';
+import axiosInstance from '@utils/axios';
+import React, { useCallback, useState } from 'react';
+import ENDPOINT from '@constants/endpoint';
+
+const { GET_DOCUMENT_BY_TITLE } = ENDPOINT;
+
+function useTitleInput(init: string) {
+  const [value, setValue] = useState<string>(init);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const isAlreadyWritten = async () => {
+    try {
+      await axiosInstance.get<WikiDocument>(`${GET_DOCUMENT_BY_TITLE}/${value}`);
+      setErrorMessage('이미 있는 문서입니다.');
+    } catch (error) {
+      setErrorMessage('');
+    }
+  };
+
+  const onChange = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    setValue(newValue);
+  }, []);
+
+  const reset = useCallback(() => {
+    setValue(init);
+    setErrorMessage('');
+  }, [init]);
+  return [value, onChange, reset, errorMessage, isAlreadyWritten] as const;
+}
+
+export default useTitleInput;

--- a/client/src/type/DocumentType.ts
+++ b/client/src/type/DocumentType.ts
@@ -13,12 +13,20 @@ export interface WriteDocumentContent {
   documentBytes: number;
 }
 
-export interface WikiDocumentLog {
+export interface WikiDocumentLogSummary {
+  documentBytes: number;
+  generateTime: string;
+  logId: number;
+  version: number;
+  writer: string;
+}
+
+export interface WikiDocumentLogDetail {
+  contents: string;
+  generateTime: string;
   logId: number;
   title: string;
-  contents: string;
   writer: string;
-  generateTime: string;
 }
 
 export interface UploadImageMeta {


### PR DESCRIPTION
# 편집로그 api 연결 및 로그 상세 연결

## 주요 변경 내용
- 편집로그 내역 api 연결 완료했습니다.
- 보기를 누르면 로그 상세로 들어갑니다.

## 참고 사항
-

## 남은 작업 내용
-

## 참고용 시연 사진
![image](https://github.com/Crew-Wiki/frontend/assets/81083461/5ce77b45-91a6-4303-b6ed-1c4499a97763)
![image](https://github.com/Crew-Wiki/frontend/assets/81083461/c8cdadfe-873d-4f59-94b1-e17fadaca957)

