### PR TITLE
Feat: 위키헤더가 본문 가리는 문제해결. 돋보기 클릭시 검색바 토글

### DIFF
--- a/client/src/components/Layout/Layout.tsx
+++ b/client/src/components/Layout/Layout.tsx
@@ -7,7 +7,7 @@ const Layout = () => {
   return (
     <div className="App">
       <WikiHeader />
-      <div className="flex items-center justify-center h-fit mt-20 max-[768px]:mt-12">
+      <div className="flex items-center justify-center h-fit">
         <main className="flex gap-6 py-6 px-4 max-w-[1440px] w-full max-[768px]:py-2 max-[768px]:px-0">
           <div className="flex flex-col gap-6 w-full max-[768px]:gap-2">
             <Outlet />

--- a/client/src/components/WikiHeader.tsx
+++ b/client/src/components/WikiHeader.tsx
@@ -50,7 +50,7 @@ const WikiHeader = () => {
 
   return (
     <motion.div
-      className="fixed top-0 w-full bg-primary-primary "
+      className="sticky top-0 w-full bg-primary-primary "
       animate={{ y }}
       transition={{ duration: 0.3 }}
     >

--- a/client/src/components/WikiHeader.tsx
+++ b/client/src/components/WikiHeader.tsx
@@ -45,15 +45,12 @@ const WikiHeader = () => {
   }, [showHeader]);
 
   const [isVisibleSmallSearchBar, setVisibleSmallSearchBar] = useState(false);
-  const toggleVisibility = ()=>{
-          setVisibleSmallSearchBar(!isVisibleSmallSearchBar);};
- 
+  const toggleVisibility = () => {
+    setVisibleSmallSearchBar(!isVisibleSmallSearchBar);
+  };
+
   return (
-    <motion.div
-      className="sticky top-0 w-full bg-primary-primary "
-      animate={{ y }}
-      transition={{ duration: 0.3 }}
-    >
+    <motion.div className="sticky top-0 w-full bg-primary-primary " animate={{ y }} transition={{ duration: 0.3 }}>
       <div className="flex flex-col justify-center items-center gap-y-4 py-2">
         <div className="flex flex-row justify-between items-center px-4 header-container max-w-[1440px] w-full">
           <Link to="/" className="flex gap-2 items-center">

--- a/client/src/components/WikiHeader.tsx
+++ b/client/src/components/WikiHeader.tsx
@@ -45,7 +45,9 @@ const WikiHeader = () => {
   }, [showHeader]);
 
   const [isVisibleSmallSearchBar, setVisibleSmallSearchBar] = useState(false);
-
+  const toggleVisibility = ()=>{
+          setVisibleSmallSearchBar(!isVisibleSmallSearchBar);};
+ 
   return (
     <motion.div
       className="sticky top-0 w-full bg-primary-primary "
@@ -62,7 +64,7 @@ const WikiHeader = () => {
           <div className="flex items-center">
             <RandomButton className="mr-4 cursor-pointer" />
             <WikiInputField className="w-20 md:w-[20.25rem] hidden md:flex" />
-            <SearchCircleSmall className="cursor-pointer md:hidden" onClick={() => setVisibleSmallSearchBar(true)} />
+            <SearchCircleSmall className="cursor-pointer md:hidden" onClick={toggleVisibility} />
           </div>
         </div>
         <div className={twMerge('flex items-center md:hidden', isVisibleSmallSearchBar ? '' : 'hidden')}>


### PR DESCRIPTION
# 위키헤더가 본문 가리는 문제해결. 돋보기 클릭시 검색바 토글

## 주요 변경 내용
- 위키헤더가 본문 가리는 문제해결
- 돋보기 클릭시 검색바 토글

## 참고 사항
- 관련이슈 : issue/#28

## 남은 작업 내용
-

## 참고용 시연 사진
-
![스크린샷 2024-04-04 111748](https://github.com/Crew-Wiki/frontend/assets/86130706/53922470-9ffc-4d87-a06c-7d53b77c963f)

