### PR TITLE
Issue: 중복된 문서일 때 버튼 비활성화

### DIFF
--- a/client/src/components/PostHeader.tsx
+++ b/client/src/components/PostHeader.tsx
@@ -7,7 +7,7 @@ interface PostHeaderProps {
   mode: 'add' | 'edit';
   onClick: () => void;
   isPending: boolean;
-  isInputEmpty: boolean;
+  disabledSubmit: boolean;
 }
 
 const MODE_TITLE: Record<string, string> = {
@@ -15,7 +15,7 @@ const MODE_TITLE: Record<string, string> = {
   edit: '편집하기',
 };
 
-const PostHeader = ({ mode, onClick, isPending, isInputEmpty }: PostHeaderProps) => {
+const PostHeader = ({ mode, onClick, isPending, disabledSubmit }: PostHeaderProps) => {
   // isPending과 validation 연산해서 버튼의 disabled 넘겨주기
   const navigate = useNavigate();
 
@@ -28,7 +28,7 @@ const PostHeader = ({ mode, onClick, isPending, isInputEmpty }: PostHeaderProps)
       <DocumentTitle title={MODE_TITLE[mode]} />
       <fieldset className="flex gap-2">
         <Button style="tertiary" size="xs" text="취소하기" onClick={goBack} />
-        <Button style="primary" size="xs" text="작성완료" onClick={onClick} disabled={isPending || isInputEmpty} />
+        <Button style="primary" size="xs" text="작성완료" onClick={onClick} disabled={isPending || disabledSubmit} />
       </fieldset>
     </header>
   );

--- a/client/src/components/TitleInputField.tsx
+++ b/client/src/components/TitleInputField.tsx
@@ -6,7 +6,7 @@ interface TitleInputFieldProps {
     title: string;
     setTitle: (event: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
     errorMessage: string;
-    isAlreadyWritten: () => Promise<void>;
+    checkIsAlreadyWritten: () => Promise<void>;
   };
   nicknameState: {
     nickname: string;
@@ -40,7 +40,7 @@ const TitleInputField = ({ titleState, nicknameState, disabled }: TitleInputFiel
             onChange={titleState.setTitle}
             maxLength={12}
             disabled={disabled}
-            onBlur={titleState.isAlreadyWritten}
+            onBlur={titleState.checkIsAlreadyWritten}
           />
         </div>
         <div className="flex w-36 h-14 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2 max-[768px]:text-sm  max-[768px]:h-10">

--- a/client/src/components/WritePage.tsx
+++ b/client/src/components/WritePage.tsx
@@ -22,7 +22,7 @@ const WritePage = ({ mode, writeDocument, isPending, defaultDocumentData }: Writ
     window.history.back();
   }
   const editorRef = useRef<Editor | null>(null);
-  const { titleState, nicknameState } = usePostPage(defaultDocumentData);
+  const { titleState, nicknameState, disabledSubmit } = usePostPage(defaultDocumentData);
   const [images, setImages] = useState<UploadImageMeta[]>([]);
 
   const getMarkup = () => {
@@ -39,8 +39,6 @@ const WritePage = ({ mode, writeDocument, isPending, defaultDocumentData }: Writ
 
     return newContents;
   };
-
-  const isInputEmpty = titleState.title === '' || nicknameState.nickname === '';
 
   const onClick = async () => {
     if (editorRef === null) return;
@@ -59,7 +57,7 @@ const WritePage = ({ mode, writeDocument, isPending, defaultDocumentData }: Writ
   };
   return (
     <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-3">
-      <PostHeader mode={mode} onClick={onClick} isPending={isPending} isInputEmpty={isInputEmpty} />
+      <PostHeader mode={mode} onClick={onClick} isPending={isPending} disabledSubmit={disabledSubmit} />
       <TitleInputField titleState={titleState} nicknameState={nicknameState} disabled={mode === 'edit'} />
       <PostContents editorRef={editorRef} initialValue={defaultDocumentData?.contents} setImages={setImages} />
     </div>

--- a/client/src/hooks/usePostPage.ts
+++ b/client/src/hooks/usePostPage.ts
@@ -3,14 +3,14 @@ import useNicknameInput from './useNicknameInput';
 import useTitleInput from './useTitleInput';
 
 const usePostPage = (defaultDocumentData?: WikiDocument) => {
-  const [title, setTitle, , titleErrorMessage, isAlreadyWritten] = useTitleInput(defaultDocumentData?.title ?? '');
-  const [nickname, setNickname, , errorMessage] = useNicknameInput(defaultDocumentData?.writer ?? '');
+  const [title, setTitle, , titleErrorMessage, checkIsAlreadyWritten] = useTitleInput(defaultDocumentData?.title ?? '');
+  const [nickname, setNickname, , errorMessage] = useNicknameInput('');
 
   const titleState = {
     title,
     setTitle,
     errorMessage: titleErrorMessage,
-    isAlreadyWritten,
+    checkIsAlreadyWritten,
   };
 
   const nicknameState = {
@@ -19,7 +19,10 @@ const usePostPage = (defaultDocumentData?: WikiDocument) => {
     errorMessage,
   };
 
-  return { titleState, nicknameState };
+  const isInputEmpty = titleState.title === '' || nicknameState.nickname === '';
+  const disabledSubmit = isInputEmpty || titleErrorMessage !== '';
+
+  return { titleState, nicknameState, disabledSubmit };
 };
 
 export default usePostPage;


### PR DESCRIPTION
# 중복된 문서일 때 버튼 비활성화

## 주요 변경 내용
- 이미 있는 문서일 때 버튼을 비활성화 시켜서 중복된 문서를 생성하지 못하도록 합니다.

## 참고 사항
- [x] #38 

## 남은 작업 내용
-

## 참고용 시연 사진
![image](https://github.com/Crew-Wiki/frontend/assets/81083461/ce41c779-27e3-4a61-94ce-f121265baaaf)

