### PR TITLE
Issue: 게시글 편집시 편집로그에 반영되지 않던 문제 해결

### DIFF
--- a/client/src/api/put/usePutDocument.ts
+++ b/client/src/api/put/usePutDocument.ts
@@ -33,6 +33,7 @@ const usePutDocument = () => {
       queryClient.removeQueries({
         queryKey: [QUERY.GET_RECENTLY_DOCUMENTS],
       });
+      queryClient.invalidateQueries({ queryKey: [QUERY.GET_DOCUMENT_LOGS] });
       navigate(`${URLS.WIKI}/${response.data.title}`);
     },
   });

--- a/client/src/api/put/usePutDocument.ts
+++ b/client/src/api/put/usePutDocument.ts
@@ -33,7 +33,7 @@ const usePutDocument = () => {
       queryClient.removeQueries({
         queryKey: [QUERY.GET_RECENTLY_DOCUMENTS],
       });
-      queryClient.invalidateQueries({ queryKey: [QUERY.GET_DOCUMENT_LOGS] });
+      queryClient.invalidateQueries({ queryKey: [QUERY.GET_DOCUMENT_LOGS, response.data.title] });
       navigate(`${URLS.WIKI}/${response.data.title}`);
     },
   });


### PR DESCRIPTION
# Feat: 게시글 편집시 편집로그에 반영되지 않던 문제 해결

## 주요 변경 내용
- #43 해결

## 참고 사항
- postDocument시 reactQuery의 해당게시글 log캐시를 invalidate 하여 구현.

## 남은 작업 내용
-

## 참고용 시연 사진
- [ 편집로그에서->편집후-> 로그를 보면 반영이 되어있음. ] 
![image](https://github.com/Crew-Wiki/frontend/assets/86130706/249671b2-4437-421a-88e9-fcc13f3faa70)

