### PR TITLE
feat: 편집 로그 상세에서 모바일에서 버튼이 보이게 설정

### DIFF
--- a/client/src/components/DocumentPage.tsx
+++ b/client/src/components/DocumentPage.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import useGetDocumentByTitle from '@api/get/useGetDocumentByTitle';
-import { useQueryClient } from '@tanstack/react-query';
-import URLS from '@constants/urls';
 import DocumentHeader from './DocumentHeader';
 import DocumentContents from './DocumentContents';
 import DocumentFooter from './DocumentFooter';
-import Button from './Button';
+import MobileDocumentHeader from './MobileDocumentHeader';
 
 interface DocumentPageProps {
   daemoon?: string;
@@ -24,35 +22,9 @@ const DocumentPage = ({ daemoon }: DocumentPageProps) => {
     }
   }, [daemoon]);
 
-  const queryClient = useQueryClient();
-
-  const refreshData = () => {
-    queryClient.removeQueries();
-    navigate('');
-  };
-
-  const goPostPage = () => {
-    navigate(URLS.POST);
-  };
-
-  const goEditPage = () => {
-    navigate(URLS.EDIT, { state: docs });
-  };
-
-  const goLogsPage = () => {
-    navigate(URLS.LOGS, { state: docs });
-  };
-
   return (
     <>
-      <div className="md:hidden">
-        <fieldset className="flex gap-2 max-md:w-full max-md:justify-center">
-          <Button style="tertiary" size="xs" text="새로고침" onClick={refreshData} />
-          <Button style="tertiary" size="xs" text="편집하기" onClick={goEditPage} />
-          <Button style="tertiary" size="xs" text="편집로그" onClick={goLogsPage} />
-          <Button style="primary" size="xs" text="작성하기" onClick={goPostPage} />
-        </fieldset>
-      </div>
+      <MobileDocumentHeader docs={docs} />
       <div className="flex flex-col gap-6 w-full h-fit min-h-[864px] bg-white border-primary-100 border-solid border rounded-xl p-8 max-md:p-4 max-md:gap-2">
         <DocumentHeader wiki={docs} />
         <DocumentContents contents={docs.contents} />

--- a/client/src/components/LogContent.tsx
+++ b/client/src/components/LogContent.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import DocumentHeader from './DocumentHeader';
 import DocumentContents from './DocumentContents';
 import DocumentFooter from './DocumentFooter';
+import MobileDocumentHeader from './MobileDocumentHeader';
 
 const LogContent = () => {
   const { logId } = useParams();
@@ -11,6 +12,7 @@ const LogContent = () => {
 
   return (
     <>
+      <MobileDocumentHeader docs={document} />
       <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-2 ">
         <DocumentHeader wiki={{ documentId: document.logId, ...document }} />
         <DocumentContents contents={document.contents} />

--- a/client/src/components/MobileDocumentHeader.tsx
+++ b/client/src/components/MobileDocumentHeader.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import URLS from '@constants/urls';
+import { useNavigate } from 'react-router-dom';
+import { WikiDocument, WikiDocumentLogDetail } from '@type/DocumentType';
+import Button from './Button';
+
+interface MobileDocumentHeaderProps {
+  docs: WikiDocumentLogDetail | WikiDocument;
+}
+
+const MobileDocumentHeader = ({ docs }: MobileDocumentHeaderProps) => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const refreshData = () => {
+    queryClient.removeQueries();
+    navigate('');
+  };
+
+  const goPostPage = () => {
+    navigate(URLS.POST);
+  };
+
+  const goEditPage = () => {
+    navigate(URLS.EDIT, { state: docs });
+  };
+
+  const goLogsPage = () => {
+    navigate(`${URLS.WIKI}/${docs.title}/${URLS.LOGS}`, { state: docs });
+  };
+
+  return (
+    <div className="md:hidden">
+      <fieldset className="flex gap-2 max-md:w-full max-md:justify-center">
+        <Button style="tertiary" size="xs" text="새로고침" onClick={refreshData} />
+        <Button style="tertiary" size="xs" text="편집하기" onClick={goEditPage} />
+        <Button style="tertiary" size="xs" text="편집로그" onClick={goLogsPage} />
+        <Button style="primary" size="xs" text="작성하기" onClick={goPostPage} />
+      </fieldset>
+    </div>
+  );
+};
+
+export default MobileDocumentHeader;


### PR DESCRIPTION
# 편집 로그 상세에서 모바일에서 버튼이 보이게 설정

## 주요 변경 내용
- 편집 로그 상세에서 모바일 모드일 시 버튼이 보이지 않았던 문제 해결

## 참고 사항
-

## 남은 작업 내용
-

## 참고용 시연 사진
![image](https://github.com/Crew-Wiki/frontend/assets/81083461/66842b1e-d19e-4d15-96fa-028013b280f2)

