### PR TITLE
issue #40: 작성/편집 캐싱 후속

### DIFF
--- a/client/src/components/WritePage.tsx
+++ b/client/src/components/WritePage.tsx
@@ -36,7 +36,7 @@ const attachBackupHandler = (editorRef: React.MutableRefObject<Editor | null>, t
     };
   };
 
-  const MARKDOWN_THROTTLE_TIME = 500;
+  const MARKDOWN_THROTTLE_TIME = 5000;
 
   const saveMarkDown = () => {
     mySessionStorage.set([KEYS.SESSION_STORAGE.WRITE, title], getMarkDown() ?? '');

--- a/client/src/components/WritePage.tsx
+++ b/client/src/components/WritePage.tsx
@@ -48,6 +48,7 @@ const attachBackupHandler = (editorRef: React.MutableRefObject<Editor | null>, t
   }
 
   const cleanup = () => {
+    mySessionStorage.remove([KEYS.SESSION_STORAGE.WRITE, title]);
     if (!timeoutId) return;
     clearTimeout(timeoutId);
   };

--- a/client/src/components/WritePage.tsx
+++ b/client/src/components/WritePage.tsx
@@ -24,20 +24,19 @@ const attachBackupHandler = (editorRef: React.MutableRefObject<Editor | null>, t
     return editorRef.current?.getInstance().getMarkdown();
   };
 
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const makeThrottle = (callback: () => void, throttleTime: number) => {
-    let isThrottle: boolean = false;
     return () => {
-      if (!isThrottle) {
-        isThrottle = true;
-        setTimeout(() => {
+      if (!timeoutId) {
+        timeoutId = setTimeout(() => {
           callback();
-          isThrottle = false;
+          timeoutId = null;
         }, throttleTime);
       }
     };
   };
 
-  const MARKDOWN_THROTTLE_TIME = 5000;
+  const MARKDOWN_THROTTLE_TIME = 500;
 
   const saveMarkDown = () => {
     mySessionStorage.set([KEYS.SESSION_STORAGE.WRITE, title], getMarkDown() ?? '');
@@ -46,10 +45,15 @@ const attachBackupHandler = (editorRef: React.MutableRefObject<Editor | null>, t
 
   if (editorRef.current !== null) {
     editorRef.current.getInstance().addHook('change', saveMarkDownThrottle);
-  } else {
-    console.log('editorRef.current는 null');
   }
+
+  const cleanup = () => {
+    if (!timeoutId) return;
+    clearTimeout(timeoutId);
+  };
+  return cleanup;
 };
+
 const WritePage = ({ mode, writeDocument, isPending, defaultDocumentData }: WritePageProps) => {
   if (mode === 'edit' && defaultDocumentData === null) {
     window.history.back();
@@ -93,7 +97,10 @@ const WritePage = ({ mode, writeDocument, isPending, defaultDocumentData }: Writ
     writeDocument(context);
   };
 
-  useEffect(() => attachBackupHandler(editorRef, titleState.title), []);
+  useEffect(() => {
+    const cleanupFn = attachBackupHandler(editorRef, titleState.title);
+    return cleanupFn;
+  }, [editorRef, titleState.title]);
   return (
     <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-3">
       <PostHeader mode={mode} onClick={onClick} isPending={isPending} disabledSubmit={disabledSubmit} />

--- a/client/src/utils/mySessionStorage.ts
+++ b/client/src/utils/mySessionStorage.ts
@@ -18,6 +18,10 @@ const mySessionStorage = {
   has(keys: string[]) {
     return this.get(keys) !== null;
   },
+
+  remove(keys: string[]) {
+    window.sessionStorage.removeItem(keys.join(SPLITTER));
+  },
 };
 
 export default mySessionStorage;


### PR DESCRIPTION
# 작성/편집 캐싱, 잦은 편집/취소시 빈 문자열이 캐싱되는 문제 해결

## 주요 변경 내용
- #40 의 후속 이슈(코멘트)에 대한 해결
- 파악한 문제 원인 : change가 감지되면, 5초 경과후 스토리지에 저장하는데, 변경후 5초이전에 Editor를 벗어나 다른페이지로 가면 그 페이지 내용이 캐싱됨 (Editor가 없어서 거의 빈문자열)

- 해결 :  문서이탈시 캐싱예약해제. 더이상 깨지지않음. (useEffect cleanup으로 캐싱예약 clearTimeout 적용.)

## 참고 사항
- 토다리가 코멘트로 단 시나리오에도 대응이 될 것 같은데 확인부탁드립니다.

## 남은 작업 내용
- WritePage가 길어져서 리팩터링 필요

## 참고용 시연 사진
- 문제 재연 : 편집하기에서 문서수정후 5초이내에 문서이탈. 이상한 문자가 캐싱됨.
https://github.com/Crew-Wiki/frontend/assets/86130706/b85fce0b-7359-4297-a622-8192825a6bd0

- 문제 해결 후 : 5초내 문서이탈시 예약된 캐싱을 제거. cleanup함수가 clearTimeout. 
https://github.com/Crew-Wiki/frontend/assets/86130706/55cd1845-36a4-4c1f-bb83-73ea87e7ef20


