### PR TITLE
fix: header 위에 contents가 위치해 가려지던 issue 해결

### DIFF
--- a/client/src/components/WikiHeader.tsx
+++ b/client/src/components/WikiHeader.tsx
@@ -60,7 +60,7 @@ const WikiHeader = () => {
   };
 
   return (
-    <motion.div className="sticky top-0 w-full bg-primary-primary " animate={{ y }} transition={{ duration: 0.3 }}>
+    <motion.div className="sticky z-50 top-0 w-full bg-primary-primary " animate={{ y }} transition={{ duration: 0.3 }}>
       <div className="flex flex-col justify-center items-center py-2">
         <div className="flex flex-row justify-between items-center px-4 header-container max-w-[1440px] w-full">
           <Link to="/" className="flex gap-2 items-center">


### PR DESCRIPTION
# header 위에 contents가 위치해 가려지던 issue 해결

## 주요 변경 내용
- header `z-index : 50` 를 통해 문제 해결

## 참고 사항
- x

## 남은 작업 내용
- x

## 참고용 시연 사진
- 
![image](https://github.com/Crew-Wiki/frontend/assets/85233397/e44b1eaa-15d7-4016-973c-e03a4ad26981)

