### PR TITLE
hotfix: 없는 문서에서 작성할 때 fallback이 사라지지 않던 오류 해결

### DIFF
--- a/client/src/api/post/usePostDocument.ts
+++ b/client/src/api/post/usePostDocument.ts
@@ -52,6 +52,9 @@ const usePostDocument = () => {
       queryClient.removeQueries({
         queryKey: [QUERY.GET_RECENTLY_DOCUMENTS],
       });
+      queryClient.removeQueries({
+        queryKey: [QUERY.GET_DOCUMENT_BY_TITLE, response.data.title],
+      });
 
       navigate(`${URLS.WIKI}/${response.data.title}`);
     },

--- a/client/src/components/DocumentFallback.tsx
+++ b/client/src/components/DocumentFallback.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { AxiosError } from 'axios';
 
 import { FallbackProps } from 'react-error-boundary';


### PR DESCRIPTION
# 없는 문서에서 작성할 때 fallback이 사라지지 않던 오류 해결

## 주요 변경 내용
- 없는 문서에서 조회한 캐시 데이터를 같이 날려줌으로서 없는 문서에서 작성하면 정상적으로 작성한 내용이 보이게 됩니다.
- #83 

## 참고 사항

## 남은 작업 내용

## 참고용 시연 사진
![image](https://github.com/Crew-Wiki/frontend/assets/81083461/f40d2ac4-e291-43ec-a6e4-4170162c451b)
