### PR TITLE
feat: s3 image upload시 random 파일명 적용

### DIFF
--- a/client/src/api/awsS3.ts
+++ b/client/src/api/awsS3.ts
@@ -20,31 +20,15 @@ const s3 = new AWS.S3({
 
 const resizeFile = (file: File) =>
   new Promise((res) => {
-    Resizer.imageFileResizer(file, 1000, 1000, 'JPEG', 70, 0, (uri) => res(uri), 'file');
+    Resizer.imageFileResizer(file, 640, 640, 'JPEG', 70, 0, (uri) => res(uri), 'file');
   });
-
-const changeDuplicatedName = (uploadImageMeats: UploadImageMeta[]) => {
-  const names: Record<string, number> = {};
-  const changedImageMetas = uploadImageMeats.map((imageMeta) => {
-    if (names[imageMeta.file.name] === 0) {
-      names[imageMeta.file.name] += 1;
-    } else {
-      names[imageMeta.file.name] = 0;
-    }
-    const newFile = new File(
-      [imageMeta.file],
-      `${names[imageMeta.file.name] ? names[imageMeta.file.name] : ''}${imageMeta.file.name}`,
-    );
-    return { ...imageMeta, file: newFile };
-  });
-  return changedImageMetas;
-};
 
 export default async function uploadImages(albumName: string, uploadImageMetas: UploadImageMeta[]) {
   const newMetas = await Promise.all(
-    changeDuplicatedName(uploadImageMetas).map(async (imageMeta) => {
+    uploadImageMetas.map(async (imageMeta) => {
+      const randomFileName = Math.random().toString(36).substr(2, 11);
       const resizedImage = (await resizeFile(imageMeta.file)) as File;
-      const uploadImageKey = `${albumName}/${imageMeta.file.name}`;
+      const uploadImageKey = `${albumName}/${randomFileName}`;
 
       const upload = s3.upload({
         ACL: 'public-read',


### PR DESCRIPTION
# S3 upload image name 중복 오류 해결

## 주요 변경 내용
- 기존의 changeDuplicatedName 함수 제거
- file 이름에 random을 통해 중복 제거

## 참고 사항
- 앞으로 복사 붙여넣기 및 기타 사진 업로드에서 중복되는 이미지가 올라가는 현상이 없을 듯 합니다

## 남은 작업 내용
- x

## 참고용 시연 사진
- x
